### PR TITLE
Fix warning errors from opening history record table

### DIFF
--- a/frontend/src/components/history/attemptInfo.js
+++ b/frontend/src/components/history/attemptInfo.js
@@ -31,8 +31,14 @@ function AttemptInfo({ open, handleClose, question, attempt }) {
         onClose={handleClose}
         aria-labelledby="customized-dialog-title"
         open={open}
-        fullWidth='xl'
-        maxWidth='xl'
+        sx={{
+          "& .MuiDialog-container": {
+            "& .MuiPaper-root": {
+              width: "100%",
+              maxWidth: "1000px",
+            },
+          },
+        }}
       >
         {/* Question title */}
       <div className="attempt-wrapper">

--- a/history-service/routes/history-route.js
+++ b/history-service/routes/history-route.js
@@ -3,7 +3,7 @@ const router = express.Router();
 
 const historyController = require("../controllers/history-controller.js");
 const auth = require('../middleware/auth.js')
-router.post("/saveAttempt", historyController.saveAttempt);
-router.post("/getHistory", historyController.getHistory);
+router.post("/saveAttempt", auth, historyController.saveAttempt);
+router.post("/getHistory", auth, historyController.getHistory);
 
 module.exports=router;


### PR DESCRIPTION
Fix warning errors from opening history record table
Add auth to history-route.js